### PR TITLE
PR: Add Image for Metrics Exporter

### DIFF
--- a/images/metrics/Dockerfile
+++ b/images/metrics/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:focal
+
+SHELL [ "/bin/bash", "-c" ]
+
+COPY . .
+
+RUN set eux; \
+    apt-get update; \
+    apt-get install -y ifstat; \
+    chmod +x gpu-util.sh network-load.sh
+
+CMD [ "./network-load.sh" ]

--- a/images/metrics/Dockerfile
+++ b/images/metrics/Dockerfile
@@ -1,3 +1,7 @@
+#
+#   Image: robolaunchio/custom-metrics-patcher:focal-v1.24.10
+#
+
 FROM ubuntu:focal
 
 SHELL [ "/bin/bash", "-c" ]
@@ -6,7 +10,11 @@ COPY . .
 
 RUN set eux; \
     apt-get update; \
-    apt-get install -y ifstat; \
+    apt-get install -y ifstat curl; \
     chmod +x gpu-util.sh network-load.sh
+
+RUN set eux; \
+    curl -LO https://dl.k8s.io/release/v1.24.10/bin/linux/amd64/kubectl; \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 CMD [ "./network-load.sh" ]

--- a/images/metrics/gpu-util.sh
+++ b/images/metrics/gpu-util.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set eux;
+
+if ! command -v nvidia-smi &> /dev/null
+then
+    echo "nvidia-smi command not found!";
+    exit 1;
+fi
+
+if [[ -z "${GPU_LATENCY}" ]]; then
+    echo "Environment GPU_LATENCY should be set.";
+    exit 1;
+fi
+
+while [ true ]
+do
+    nvidia-smi | grep "%" | awk '{print $13}';
+    sleep "$GPU_LATENCY";
+    # kubectl patch metricsexporter metricsexporter-sample --type=merge -n test --patch '{"spec":{"foo":"asd"}}'
+done

--- a/images/metrics/network-load.sh
+++ b/images/metrics/network-load.sh
@@ -2,9 +2,61 @@
 
 set eux;
 
+trap ctrl_c INT;
+
+function ctrl_c() {
+    echo "Ending collecting network load data...";
+    pkill -P $$;
+    exit 0;
+}
+
+if [[ -z "${METRICS_EXPORTER_NAME}" ]]; then
+    echo "Environment METRICS_EXPORTER_NAME should be set.";
+    exit 1;
+fi
+
+if [[ -z "${METRICS_EXPORTER_NAMESPACE}" ]]; then
+    echo "Environment METRICS_EXPORTER_NAMESPACE should be set.";
+    exit 1;
+fi
+
+if [[ -z "${INTERVAL}" ]]; then
+    echo "Environment INTERVAL should be set.";
+    exit 1;
+fi
+
 if [[ -z "${NETWORK_INTERFACES}" ]]; then
     echo "Environment NETWORK_INTERFACES should be set.";
     exit 1;
 fi
 
-ifstat -nb -i "$NETWORK_INTERFACES" 2 5;
+ifstat -nb -i "$NETWORK_INTERFACES" $INTERVAL > network-load.txt &
+sleep $INTERVAL;
+
+while [ true ]
+do
+    COLLECTIVE_LOAD="";
+    INDEX=0;
+    IFS=,;
+    for INTERFACE in $NETWORK_INTERFACES;
+    do
+        if [[ $INDEX -ne 0 ]]; then
+            COLLECTIVE_LOAD="$COLLECTIVE_LOAD, "
+        fi
+        COLUMN_NUMBER_IN=$((INDEX*2+1))
+        COLUMN_NUMBER_OUT=$((COLUMN_NUMBER_IN+1))
+        INTERFACE_IN=$(cat network-load.txt | tail -1 | awk "{print \$$COLUMN_NUMBER_IN}")
+        INTERFACE_OUT=$(cat network-load.txt | tail -1 | awk "{print \$$COLUMN_NUMBER_OUT}")
+        COLLECTIVE_LOAD="$COLLECTIVE_LOAD\"$INTERFACE\": {\"in\": \"$INTERFACE_IN Kbps\", \"out\": \"$INTERFACE_OUT Kbps\"}"
+        INDEX=$((INDEX+1))
+    done
+    IFS=" ";
+    COLLECTIVE_LOAD="{$COLLECTIVE_LOAD}";
+    kubectl patch metricsexporter $METRICS_EXPORTER_NAME \
+        --type=merge \
+        --subresource status \
+        -n $METRICS_EXPORTER_NAMESPACE \
+        --patch \
+        "{\"status\": {\"usage\": {\"network\": {\"load\": $COLLECTIVE_LOAD}}}}"
+    sleep $INTERVAL;
+done

--- a/images/metrics/network-load.sh
+++ b/images/metrics/network-load.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set eux;
+
+if [[ -z "${NETWORK_INTERFACES}" ]]; then
+    echo "Environment NETWORK_INTERFACES should be set.";
+    exit 1;
+fi
+
+ifstat -nb -i "$NETWORK_INTERFACES" 2 5;


### PR DESCRIPTION
# :herb: PR: Add Image for Metrics Exporter

## Description

Metrics exporter image
- collects volatile GPU utilization
- collects loads of desired network interfaces 
- patches `metricsexporters.robot.roboscale.io` resource (robolaunch/robot-operator#89)

Closes #12

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How can it be tested?

It can be tested in `metricsexporters.robot.roboscale.io` resource. The ultimate image name is `robolaunchio/custom-metrics-patcher:latest`. Operator currently uses `robolaunchio/custom-metrics-patcher:focal-v1.24.10`.
