### PR TITLE
PR: Interrupt Setup Script If the User is not Root

### DIFF
--- a/instance-setup/cloud-instance/run.sh
+++ b/instance-setup/cloud-instance/run.sh
@@ -149,6 +149,12 @@ opening () {
     printf "\n";
 }
 
+check_if_root () {
+    if [ $USER != "root" ]; then
+        print_err "You should switch to root using \"sudo -i\" before setup."
+    fi
+}
+
 install_pre_tools () {
     print_log "Installing Tools...";
     # apt packages
@@ -354,6 +360,7 @@ display_connection_hub_key () {
 }
 
 print_global_log "Waiting for the preflight checks...";
+(check_if_root)
 (install_pre_tools)
 (get_versioning_map)
 

--- a/instance-setup/physical-instance/run.sh
+++ b/instance-setup/physical-instance/run.sh
@@ -200,6 +200,11 @@ opening () {
     printf "\n";
 }
 
+check_if_root () {
+    if [ $USER != "root" ]; then
+        print_err "You should switch to root using \"sudo -i\" before setup."
+    fi
+}
 
 install_pre_tools () {
     print_log "Installing Tools...";
@@ -395,6 +400,7 @@ EOF
 }
 
 print_global_log "Waiting for the preflight checks...";
+(check_if_root)
 (install_pre_tools)
 (get_versioning_map)
 


### PR DESCRIPTION
# :herb: PR: Interrupt Setup Script If the User is not Root

## Description

In preflight checks, script checks the current Linux user and interrupts script if the user is not root.

Closes #21