### PR TITLE
PR: Add Option for Skipping Platform Integration

### DIFF
--- a/instance-setup/physical-instance/README.md
+++ b/instance-setup/physical-instance/README.md
@@ -19,6 +19,7 @@ Run the following commands to register physical instance:
 # inside physical instance
 sudo -i # login as root
 export CONNECTION_HUB_KEY="<REDACTED>" # enter the key obtained previous section
+export SKIP_PLATFORM=true
 export ORGANIZATION=sample-org
 export TEAM=sample-team
 export REGION=sample-region


### PR DESCRIPTION
# :herb: PR: Add Option for Skipping Platform Integration

## Description

Platform integration can be skipped by setting `SKIP_PLATFORM` environment variable `true`.

Closes #23

## Type of change

- [x] This change requires a documentation update