### PR TITLE
PR: Add Label for Platform Version

### DIFF
--- a/instance-setup/cloud-instance/run.sh
+++ b/instance-setup/cloud-instance/run.sh
@@ -210,6 +210,7 @@ label_node () {
     print_log "Labeling node...";
     check_node_name;
     kubectl label --overwrite=true node $NODE_NAME \
+        robolaunch.io/platform=$PLATFORM_VERSION \
         robolaunch.io/organization=$ORGANIZATION \
         robolaunch.io/region=$REGION \
         robolaunch.io/team=$TEAM \

--- a/instance-setup/physical-instance/run.sh
+++ b/instance-setup/physical-instance/run.sh
@@ -246,6 +246,7 @@ label_node () {
     print_log "Labeling node...";
     check_node_name;
     kubectl label --overwrite=true node $NODE_NAME \
+        robolaunch.io/platform=$PLATFORM_VERSION \
         robolaunch.io/organization=$ORGANIZATION \
         robolaunch.io/region=$REGION \
         robolaunch.io/team=$TEAM \


### PR DESCRIPTION
# :herb: PR: Add Label for Platform Version

## Description

- Nodes will be labeled specifying the platform version. `robolaunch.io/platform` will be used as key.

Closes #41