### PR TITLE
PR: Generate ROS 2 Bridge Images

### DIFF
--- a/dockerfiles/ros2/Dockerfile.bridge
+++ b/dockerfiles/ros2/Dockerfile.bridge
@@ -1,0 +1,10 @@
+
+ARG BASE_IMAGE="ubuntu:20.04"
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-c"]
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG ROS_DISTRO_CODE=foxy
+
+RUN apt update && apt install -y ros-${ROS_DISTRO_CODE}-rosbridge-suite

--- a/pipelines/ros2/foxy-bridge.yaml
+++ b/pipelines/ros2/foxy-bridge.yaml
@@ -1,0 +1,31 @@
+name: foxy-bridge
+registry: docker.io
+organization: robolaunchio
+version: 0.2.6-alpha.18
+steps:
+- name: foxy-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-foxy-plain
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile"
+  buildArgs: 
+    "BASE_IMAGE": "ubuntu:jammy"
+    "ROS_DISTRO_CODE": "foxy"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true
+- name: foxy-bridge
+  baseStep: foxy-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-foxy-bridge
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile.bridge"
+  buildArgs: 
+    "ROS_DISTRO_CODE": "foxy"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true

--- a/pipelines/ros2/galactic-bridge.yaml
+++ b/pipelines/ros2/galactic-bridge.yaml
@@ -1,0 +1,31 @@
+name: galactic-bridge
+registry: docker.io
+organization: robolaunchio
+version: 0.2.6-alpha.18
+steps:
+- name: galactic-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-galactic-plain
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile"
+  buildArgs: 
+    "BASE_IMAGE": "ubuntu:jammy"
+    "ROS_DISTRO_CODE": "galactic"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true
+- name: galactic-bridge
+  baseStep: galactic-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-galactic-bridge
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile.bridge"
+  buildArgs: 
+    "ROS_DISTRO_CODE": "galactic"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true

--- a/pipelines/ros2/humble-bridge.yaml
+++ b/pipelines/ros2/humble-bridge.yaml
@@ -1,0 +1,31 @@
+name: humble-bridge
+registry: docker.io
+organization: robolaunchio
+version: 0.2.6-alpha.18
+steps:
+- name: humble-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-humble-plain
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile"
+  buildArgs: 
+    "BASE_IMAGE": "ubuntu:jammy"
+    "ROS_DISTRO_CODE": "humble"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true
+- name: humble-bridge
+  baseStep: humble-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-humble-bridge
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile.bridge"
+  buildArgs: 
+    "ROS_DISTRO_CODE": "humble"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true

--- a/pipelines/ros2/iron-bridge.yaml
+++ b/pipelines/ros2/iron-bridge.yaml
@@ -1,0 +1,31 @@
+name: iron-bridge
+registry: docker.io
+organization: robolaunchio
+version: 0.2.6-alpha.18
+steps:
+- name: iron-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-iron-plain
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile"
+  buildArgs: 
+    "BASE_IMAGE": "ubuntu:jammy"
+    "ROS_DISTRO_CODE": "iron"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true
+- name: iron-bridge
+  baseStep: iron-plain
+  image:
+    repository: devspace-robotics
+    tag: ros2-iron-bridge
+  path: "dockerfiles/ros2"
+  dockerfile: "Dockerfile.bridge"
+  buildArgs: 
+    "ROS_DISTRO_CODE": "iron"
+  platforms:
+  - "linux/amd64"
+  - "linux/arm64"
+  push: true


### PR DESCRIPTION
# :herb: PR: Generate ROS 2 Bridge Images

## Description

- A generic Dockerfile is added for installing `ros-<DISTRO>-rosbridge-suite`
- Pipelines are added for the ROS 2 distributions:
  - Iron
  - Humble
  - Galactic
  - Foxy

Closes #62 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested by running the pipelines using `cosmodrome`.
